### PR TITLE
verify-calls: check that `call.stack` is defined

### DIFF
--- a/verify-calls.js
+++ b/verify-calls.js
@@ -5,6 +5,7 @@ function verifyOnlyAsyncOrSync (sync, trackFile, callback) {
   var track   = require(trackFile)
     , fscalls = track.calls.filter(function (call) {
         return call.module == 'fs'
+          && call.stack
           && call.stack[0].file != 'module.js'
           && call.stack[0].file != 'fs.js'
       })


### PR DESCRIPTION
This prevents [learnyounode](https://github.com/rvagg/learnyounode) from erroring out on the MAKE IT MODULAR exercise.
