### PR TITLE
make rootdir replacement global

### DIFF
--- a/print-text.js
+++ b/print-text.js
@@ -18,7 +18,7 @@ function printText (name, appDir, file, callback) {
       contents = contents.replace(new RegExp('\\{' + k + '\\}', 'gi'), variables[k])
     })
     // proper path resolution
-    contents = contents.replace(/\{rootdir:([^}]+)\}/, function (match, subpath) {
+    contents = contents.replace(/\{rootdir:([^}]+)\}/gi, function (match, subpath) {
       return path.join(appDir, subpath)
     })
     console.log(contents)


### PR DESCRIPTION
I noticed that in learnyounode's My First I/O module, only the first `{rootdir:...}` token was replaced. 

> Documentation on `Buffer`s can be found by pointing your browser here:
>   {rootdir:/node_apidoc/buffer.html}

I worked the fault back to this line where only the first instance was being replaced.
