### PR TITLE
Clear menu before printing exercise.

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -40,7 +40,9 @@ function showMenu (opts) {
   
   menu.on('select', function (label) {
     var name = label.replace(/(^[^»]+»[^\s]+ )|(\s{2}.*)/g, '')
-    
+
+    menu.y = 0
+    menu.reset()
     menu.close()
 
     if (name === bold('EXIT'))


### PR DESCRIPTION
When you select an exercise, it prints the content directly below the menu, which looks a little messy.

![screen shot 2013-09-22 at 2 55 56 pm](https://f.cloud.github.com/assets/43438/1187104/101121b6-2354-11e3-988f-b3c724b61fb8.png)
![screen shot 2013-09-22 at 2 52 59 pm](https://f.cloud.github.com/assets/43438/1187102/ec9cad54-2353-11e3-947c-710d4812f68e.png)

This patch clears the menu before it prints the exercise problem.txt.

![screen shot 2013-09-22 at 2 55 56 pm](https://f.cloud.github.com/assets/43438/1187104/101121b6-2354-11e3-988f-b3c724b61fb8.png)
![screen shot 2013-09-22 at 3 00 52 pm](https://f.cloud.github.com/assets/43438/1187116/ec1619b4-2354-11e3-936d-33cac8f1adc2.png)

This also makes the alignment + width difference between the problem text and the menu/title less noticeable too.

The menu is still available if a user scrolls up:

![screen shot 2013-09-22 at 3 01 01 pm](https://f.cloud.github.com/assets/43438/1187114/cc44ec50-2354-11e3-923e-2c56184a1c86.png)
