### PR TITLE
Add "print" to the help menu

### DIFF
--- a/usage.txt
+++ b/usage.txt
@@ -8,6 +8,8 @@
     Select a workshop.
   {bold}{green}{appname}{/green} current{/bold}
     Show the currently selected workshop.
+  {bold}{green}{appname}{/green} print{/bold}
+    Print the instructions for the currently selected workshop.
   {bold}{green}{appname}{/green} run program.js{/bold}
     Run your program against the selected input.
   {bold}{green}{appname}{/green} verify program.js{/bold}


### PR DESCRIPTION
It looks like print was omitted from the help menu's "Usage" section.

Arguably, "print" is a lot more helpful than "current" so maybe current should just be replaced. But this will at least make the help menu more complete.
