### PR TITLE
Added opts.hideSolutions to not show the solutions when complete

### DIFF
--- a/workshopper.js
+++ b/workshopper.js
@@ -249,6 +249,10 @@ Workshopper.prototype._printUsage = function () {
 function onpass (setup, dir, current) {
   console.log(bold(green('# PASS')))
   console.log('\nYour solution to ' + current + ' passed!')
+
+  if (setup.hideSolutions)
+    return
+
   console.log('\nHere\'s what the official solution is if you want to compare notes:\n')
 
   var solutions = fs.readdirSync(dir).filter(function (file) {


### PR DESCRIPTION
This little patch allows the `setup.js` file to determine if a solution should be shown after it's completed.

Use case:

I'm working on nodeschool/discussions#4 and am trying to process a working version of their package.json. Using this option I can do the logic myself, but I don't need them to see the source of the solution.
