### PR TITLE
Kill child processes when we exit

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -42,6 +42,10 @@ function verify (acmd, bcmd, opts) {
     kill()
     tr.emit('fail')
   })
+  
+  process.once('exit', function () {
+      kill()
+  });
 
   tr = through()
   tr.pipe(opts.a || a.stdin)


### PR DESCRIPTION
Without this the child processes continue to run for me locally.  The kill() in fail and pass can be removed.
