### PR TITLE
prepend file:// to help file paths

### DIFF
--- a/print-text.js
+++ b/print-text.js
@@ -24,7 +24,7 @@ function printText (name, appDir, file, filetype, callback) {
     })
     // proper path resolution
     contents = contents.replace(/\{rootdir:([^}]+)\}/gi, function (match, subpath) {
-      return path.join(appDir, subpath)
+      return 'file://' + path.join(appDir, subpath)
     })
     if (filetype == '.md') {
       // convert Markdown to ANSI


### PR DESCRIPTION
This makes help files click-able in e.g. gnome-terminal, which is nice if you want to open up the help file quick. Is this something we want in general? Unsure how this turns out on windows.
