### PR TITLE
ignore only ''/null, null/'' when testing solution

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -61,6 +61,14 @@ function colourfn (type) {
 function compare (actual, expected, opts) {
   var equal  = true
     , write = function (pair) {
+        //passthru null/'', ''/null
+        //so console.log in given solution can match
+        //.pipe(process.stdout) in user's solution
+        if((pair[0] === '' || pair[0] === null) &&
+           (pair[1] === '' || pair[1] === null)){
+          return;
+        }
+
         var eq = pair[0] === pair[1]
 
         equal = equal && eq


### PR DESCRIPTION
allow user to output using console.log, .pipe(process.stdout),
process.stdout.write etc. as desired.
Some of these methods append newlines, some do not.  This change allows
the learner to focus on the lesson at hand and not get hung up on why
they're outputting `null` when the solution outputs `''`
