### PR TITLE
opts.solution, opts.submission arguments

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -12,8 +12,11 @@ const wrap    = require('./term-util').wrap
 function verify (acmd, bcmd, opts) {
   if (!opts) opts = {}
 
-  var a = spawn(process.execPath, acmd)
-    , b
+  var a = opts.submission
+    ? opts.submission(acmd)
+    : spawn(process.execPath, acmd)
+
+  var b
     , c
     , tr
     , kill = function () {
@@ -24,14 +27,17 @@ function verify (acmd, bcmd, opts) {
       }
 
   if (opts.run) {
-    ;(opts.a || a.stdout).pipe(process.stdout)
-    ;(opts.a || a.stdout).on('end', kill)
+    ;(opts.a || a.stdout || a).pipe(process.stdout)
+    ;(opts.a || a.stdout || a).on('end', kill)
     if (a.stderr) a.stderr.pipe(process.stderr)
-    return opts.a || a.stdin
+    return opts.a || a.stdin || a
   }
 
-  b = spawn(process.execPath, bcmd)
-  c = compare(opts.a || a.stdout, opts.b || b.stdout, opts)
+  b = opts.solution
+    ? opts.solution(bcmd)
+    : spawn(process.execPath, bcmd)
+
+  c = compare(opts.a || a.stdout || a, opts.b || b.stdout || b, opts)
 
   c.on('pass', function () {
     kill()

--- a/workshopper.js
+++ b/workshopper.js
@@ -4,6 +4,7 @@ const argv       = require('optimist').argv
     , mkdirp     = require('mkdirp')
     , map        = require('map-async')
     , msee       = require('msee')
+    , xtend      = require('xtend')
 
 const showMenu  = require('./menu')
     , verify    = require('./verify')
@@ -189,13 +190,10 @@ Workshopper.prototype.runSolution = function (setup, dir, current, run) {
 
   var a   = submissionCmd(setup)
     , b   = solutionCmd(dir, setup)
-    , v   = verify(a, b, {
-          a      : setup.a
-        , b      : setup.b
-        , long   : setup.long
-        , run    : run
+    , v   = verify(a, b, xtend(setup, {
+          run    : run
         , custom : setup.verify
-      })
+      }))
 
   v.on('pass', onpass.bind(this, setup, dir, current))
   v.on('fail', onfail.bind(this, setup, dir, current))


### PR DESCRIPTION
Right now submitted code is always run through `spawn()`. This is inflexible and has lead to a proliferation of hacks to add extra parameters to the spawn process like `opts.args`. This patch adds `opts.solution` and `opts.submission` that each take the command array as arguments and return a process object or a stream. With these changes, we can have workshopper levels that have their own custom pipeline, which is important for browserify adventure.