### PR TITLE
Updating API to default to problems directory

### DIFF
--- a/workshopper.js
+++ b/workshopper.js
@@ -31,7 +31,7 @@ function Workshopper (options) {
     throw new TypeError('need to provide a `title` String option')
 
   if (typeof options.exerciseDir != 'string')
-    throw new TypeError('need to provide an "exerciseDir" String option')
+    options.exerciseDir = path.join(options.appDir, 'problems')
 
   stat = fs.statSync(options.exerciseDir)
   if (!stat || !stat.isDirectory())


### PR DESCRIPTION
The documentation suggests that exercises directory should be `./problems`, but the example `bin` doesn't have the option listed. This throws an error. Rather than updating the documentation, I figured it would be best to simply default to a `problems` directory.
