### PR TITLE
Menu breaks when opts.extra is not set

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -60,7 +60,7 @@ function showMenu (opts) {
     if (name === 'HELP')
       return emitter.emit('help')
 
-    if (opts.extras.indexOf(name.toLowerCase()) != -1)
+    if (opts.extras && opts.extras.indexOf(name.toLowerCase()) != -1)
       return emitter.emit('extra-' + name.toLowerCase())
 
     emitter.emit('select', name)


### PR DESCRIPTION
I was trying out the master branch of [makemehapi](https://github.com/spumko/makemehapi) and found that selecting any of the menu options resulted in this error:

```
/usr/local/lib/node_modules/makemehapi/node_modules/workshopper/menu.js:63
    if (opts.extras.indexOf(name.toLowerCase()) != -1)
                    ^
TypeError: Cannot call method 'indexOf' of undefined
```

This could just be a bug in makemehapi, but since menu.js contained a different conditional  at line 41 which checked for `opts.extras` before acting on it, I figured that `opts.extras` shouldn't be assumed.

Feel free to close out if I'm wrong.
