### PR TITLE
catch `fs.statSync()` error in `loadExercise()`

### DIFF
--- a/workshopper.js
+++ b/workshopper.js
@@ -427,7 +427,11 @@ Workshopper.prototype.loadExercise = function (name) {
   if (!meta)
     return null
 
-  stat = fs.statSync(meta.exerciseFile)
+  try {
+    stat = fs.statSync(meta.exerciseFile)
+  } catch (err) {
+    return error('ERROR:', meta.exerciseFile, 'does not exist!')
+  }
 
   if (!stat || !stat.isFile())
     return error('ERROR:', meta.exerciseFile, 'does not exist!')


### PR DESCRIPTION
Hello, @rvagg and other nice `workshopper` people!

I've started looking at `workshopper` to add i18n support and I stumbled across a small problem: the `fs.statSync()` function throws an error rather than return a falsy value if the exercise file doesn't exist. This pull request adds a `try...catch` to catch the error.

I've got another general patch for the bundled example and `makews.js`. Would you rather I send a separate pull request for that patch or just add it to this one?

Thanks a bunch for `workshopper`!
