### PR TITLE
Translation

### DIFF
--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -3,7 +3,7 @@
       "exit": "終了する"
     , "help": "ヘルプを表示する"
     , "completed": "完了済み"
-    , "language": "言語を選択する"
+    , "language": "言語を選択する (CHOOSE LANGUAGE)"
     , "cancel": "キャンセル"
   }
 , "language": {

--- a/menu.js
+++ b/menu.js
@@ -1,4 +1,4 @@
-const tmenu        = require('terminal-menu')
+const tmenu        = require('extended-terminal-menu')
     , path         = require('path')
     , fs           = require('fs')
     , xtend        = require('xtend')

--- a/menu.js
+++ b/menu.js
@@ -30,8 +30,7 @@ function showMenu (opts, i18n) {
   }
   
   function addEntry(entry) {
-    var width = opts.width
-    menu.add(applyTextMarker(entry.name, entry.marker || '', width), emit(entry.event, entry.payload))
+    menu.add(applyTextMarker(entry.name, entry.marker || '', opts.width), emit(entry.event, entry.payload))
   }
 
   function addVariableEntry(variableEntry) {

--- a/menu.js
+++ b/menu.js
@@ -1,4 +1,4 @@
-const tmenu        = require('extended-terminal-menu')
+const tmenu        = require('terminal-menu')
     , path         = require('path')
     , fs           = require('fs')
     , xtend        = require('xtend')

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "chalk": "~0.4.0",
     "colors-tmpl": "~0.1.0",
+    "extended-terminal-menu": "^0.3.2",
     "i18n-core": "^1.3.2",
     "map-async": "~0.1.1",
     "mkdirp": "~0.3.5",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,12 @@
   "dependencies": {
     "chalk": "~0.4.0",
     "colors-tmpl": "~0.1.0",
-    "extended-terminal-menu": "^0.3.2",
     "i18n-core": "^1.3.2",
     "map-async": "~0.1.1",
     "mkdirp": "~0.3.5",
     "msee": "~0.1.1",
     "optimist": "~0.6.1",
-    "terminal-menu": "~0.3.2",
+    "terminal-menu": "^1.0.2",
     "visualwidth": "~0.0.1",
     "xtend": "~3.0.0"
   },


### PR DESCRIPTION
The existing translation pull request didn't cover a lot of missing translation parts. This pull requests aims to completely translate the workshoppers.

Plan:
- [x] Integrate translation system that can be applied to every string shown to the people
- [x] Add test files for another translation system
- [x] Fixed menu system 
- [x] Add translation selector
- [x] Store the language selection
- [x] Add command line arguments to the workshopper
- [x] Add translation support to the "problem.md" files.
- [x] Add a fallback in case a language of a workshop is not covered by the workshopper general module
- [x] Merge the [chinese translation](https://github.com/lisposter/learnyounode) to learnyounode
- [x] Update workshopper-exercise to work properly with the translation settings
- [x] Make solution files translatable
- [x] Make the language selection from the command line insensitive to "-" and "_" mistakes and upper-lowercase (zh-cn vs. zh-CN vs. zh_ch)
- [x] Prepare learnyounode for tests
- [x] Test every case where output is desired and see if it still works
- [x] Merge the [spanish translation](https://github.com/pdjota/learnyounode/tree/translation-es) to learnyounode
- [x] Merge the [taiwanese translation](https://github.com/cfsghost/learnyounode/tree/tanslation-zh-tw) to learnyounode
- [x] Clean up the workshopper.js code
- [x] Move translation that belongs to workshopper-exercise from workshopper to workshopper exercise 
- [x] See if it works with levelmeup