### PR TITLE
Adding 'next' command to workshopper

### DIFF
--- a/usage.txt
+++ b/usage.txt
@@ -10,6 +10,8 @@
     Show the currently selected workshop.
   {bold}{green}{appname}{/green} print{/bold}
     Print the instructions for the currently selected workshop.
+  {bold}{green}{appname}{/green} next{/bold}
+    Print the instructions for the next incomplete workshop.
   {bold}{green}{appname}{/green} reset{/bold}
     Reset completed workshop progress.
   {bold}{green}{appname}{/green} run program.js{/bold}

--- a/usage.txt
+++ b/usage.txt
@@ -11,7 +11,7 @@
   {bold}{green}{appname}{/green} print{/bold}
     Print the instructions for the currently selected workshop.
   {bold}{green}{appname}{/green} next{/bold}
-    Print the instructions for the next incomplete workshop.
+    Print the instructions for the next incomplete workshop after the currently selected workshop.
   {bold}{green}{appname}{/green} reset{/bold}
     Reset completed workshop progress.
   {bold}{green}{appname}{/green} run program.js{/bold}

--- a/workshopper.js
+++ b/workshopper.js
@@ -149,6 +149,10 @@ function Workshopper (options) {
 
     return this.execute(exercise, argv._[0], argv._.slice(1))
   }
+  
+  if (argv._[0] == 'next') {
+    return onselect.call(this, this.exercises[this.getData('completed').length])
+  }
 
   if (argv._[0] == 'reset') {
     this.reset()

--- a/workshopper.js
+++ b/workshopper.js
@@ -151,7 +151,18 @@ function Workshopper (options) {
   }
   
   if (argv._[0] == 'next') {
-    return onselect.call(this, this.exercises[this.getData('completed').length])
+    var remainingAfterCurrent = this.exercises.slice(this.exercises.indexOf(this.current))
+    
+    var completed = this.getData('completed')    
+    var incompleteAfterCurrent = remainingAfterCurrent.filter(function (elem) {
+      return completed.indexOf(elem) < 0
+    })
+    
+    if (incompleteAfterCurrent.length === 0) {
+      return console.log('There are no incomplete exercises after the current exercise\n')
+    }
+    
+    return onselect.call(this, incompleteAfterCurrent[0])
   }
 
   if (argv._[0] == 'reset') {

--- a/workshopper.js
+++ b/workshopper.js
@@ -158,9 +158,8 @@ function Workshopper (options) {
       return completed.indexOf(elem) < 0
     })
     
-    if (incompleteAfterCurrent.length === 0) {
+    if (incompleteAfterCurrent.length === 0)
       return console.log('There are no incomplete exercises after the current exercise\n')
-    }
     
     return onselect.call(this, incompleteAfterCurrent[0])
   }


### PR DESCRIPTION
Currenty, when a student finishes an exercise, the only way to print instructions for the next exercise is to fire up the workshopper menu, navigate down with down arrow key to the next exercise, and press enter.

The `next` command provides an easy way to quickly navigate to the next exercise:

```
appname next
```

This will print the instruction for the next incomplete exercise and updates workshopper's "current" exercise reference internally.