### PR TITLE
fix TypeError on getExcerciseMeta

### DIFF
--- a/workshopper.js
+++ b/workshopper.js
@@ -391,6 +391,9 @@ Workshopper.prototype._printUsage = function () {
 }
 
 Workshopper.prototype.getExerciseMeta = function (name) {
+  if (!name)
+    return false
+
   name = name.toLowerCase().trim()
 
   var number


### PR DESCRIPTION
When the user wants to print instructions directly from command line for a given workshop (for example: `learnyounode print`) and there is no current workshop selected, `getExerciseMeta` receives a `null` argument, resulting in the following error:

```javascript
  name = name.toLowerCase().trim()
              ^
TypeError: Cannot call method 'toLowerCase' of null
```

This PR fixes this problem by preventing the execution of `getExerciseMeta` in this scenario

