### PR TITLE
Add checking active exercise on `next` workshopper command 

### DIFF
--- a/workshopper.js
+++ b/workshopper.js
@@ -158,6 +158,10 @@ function Workshopper (options) {
     var remainingAfterCurrent = this.exercises.slice(this.exercises.indexOf(this.current))
 
     var completed = this.getData('completed')
+
+    if (!completed)
+      return error(this.__('error.exercise.none_active') + '\n')
+
     var incompleteAfterCurrent = remainingAfterCurrent.filter(function (elem) {
       return completed.indexOf(elem) < 0
     })


### PR DESCRIPTION
When I'm trying get `next` exercise with none active exercise:
![1 ruslan net www workshopper zsh 2015-01-30 09-51-37](https://cloud.githubusercontent.com/assets/2136166/5972177/41daa904-a866-11e4-90b7-ad01d2c233b4.jpg)

Show `none_active` error:
![1 ruslan net www workshopper zsh 2015-01-30 09-53-00](https://cloud.githubusercontent.com/assets/2136166/5972195/6bf9fde8-a866-11e4-97b1-6489b3702c87.jpg)

