### PR TITLE
Full FR L10n for the workshopper

### DIFF
--- a/examples/foo.js
+++ b/examples/foo.js
@@ -10,4 +10,5 @@ workshopper({
   , title       : 'FOO OR DIE'
   , exerciseDir : path.join(__dirname, 'exercises')
   , appDir      : __dirname
+  , languages   : ['en', 'es', 'fr', 'ja', 'pt-br', 'ru', 'zh-cn', 'zh-tw']
 })

--- a/i18n.js
+++ b/i18n.js
@@ -25,7 +25,7 @@ function i18nChain() {
         result = current.handler.get(key)
         current = current.next
       }
-      
+
       return result
     }
   }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9,6 +9,7 @@
 , "language": {
       "_current": "CURRENT"
     , "en": "English"
+    , "fr": "French (français)"
     , "ja": "Japanese (日本語)"
     , "zh-cn": "Chinese (中文)"
     , "zh-tw": "Taiwanese (國語)"

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -9,6 +9,7 @@
 , "language": {
       "_current": "CURRENT"
     , "en": "Inglés (English)"
+    , "fr": "Francés (français)"
     , "ja": "Japonés (日本語)"
     , "zh-cn": "Chino (中文)"
     , "zh-tw": "Idioma Taiwanés (國語)"

--- a/i18n/footer/fr.md
+++ b/i18n/footer/fr.md
@@ -1,0 +1,4 @@
+ __»__ Pour ré-afficher ces instructions, faites : `{appname} print`
+ __»__ Pour exécuter votre programme dans un environnement de test, faites : `{appname} run program.js`
+ __»__ Pour vérifier que votre programme résoud l’exercice, faites : `{appname} verify program.js`
+ __»__ Pour de l’aide sur les commandes, faites : `{appname} help`

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1,0 +1,59 @@
+{
+  "menu": {
+      "exit": "QUITTER"
+    , "help": "AIDE"
+    , "completed": "FAIT"
+    , "language": "CHOISIR LA LANGUE"
+    , "cancel": "ANNULER"
+  }
+, "language": {
+      "_current": "ACTUEL"
+    , "en": "Anglais (English)"
+    , "fr": "Français"
+    , "ja": "Japonais (日本語)"
+    , "zh-cn": "Chinois (中文)"
+    , "zh-tw": "Taiwanais (國語)"
+    , "es": "Espagnol (Español)"
+    , "pt-br": "Portugais brésilien (Português)"
+  }
+, "error": {
+      "exercise": {
+          "none_active": "Aucun exercice en cours.  Choisissez-en un dans le menu."
+        , "missing": "L’exercice {{{name}}} est introuvable."
+        , "unexpected_error": "Impossible de {{mode}} : {{{err}}}"
+        , "missing_file": "ERREUR : {{{exerciseFile}}} n’existe pas !"
+        , "not_a_workshopper": "ERREUR : {{{exerciseFile}}} n’est pas un exercice d’atelier"
+        , "preparing": "Erreur à la préparation de l’exercice : {{{err}}}"
+        , "loading": "Erreur au chargement du texte de l’exercice : {{{err}}}"
+      }
+    , "no_uncomplete_left": "Il ne reste aucun exercice à faire après l’exercice actuel."
+    , "cleanup": "Erreur au nettoyage : {{{err}}}"
+  }
+, "solution": {
+      "fail": {
+          "title": "RATÉ"
+        , "message": "Votre solution pour {{{name}}} n’a pas marché. Réessayez !\n"
+      }
+    , "pass": {
+          "title": "RÉUSSI"
+        , "message": "Votre solution pour {{{name}}} a fonctionné !"
+      }
+    , "notes": {
+          "compare": "Voici la solution officielle, si vous voulez comparer :\n"
+        , "load_error": "ERREUR : Un problème est survenu durant l’affichage des fichiers de solution : {{{err}}}"
+      }
+  }
+, "ui": {
+      "return": "Tapez '{{appName}}' pour afficher le menu.\n"
+    , "usage": "Utilisation : {{appName}} {{mode}} ma-tentative.js"
+  }
+, "progress": {
+      "reset": "La progression de {{title}} a été réinitialisée"
+    , "finished": "Vous avez terminé tous les défis ! Bravo !\n"
+    , "state": "Exercice {{count}} sur {{amount}}"
+    , "remaining": {
+          "one": "Il vous reste un défi"
+        , "other": "Il vous reste {{count}} défis."
+      }
+  }
+}

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -9,6 +9,7 @@
 , "language": {
       "_current": "現在の言語"
     , "en": "英語 (English)"
+    , "fr": "フランス語 (français)"
     , "ja": "日本語"
     , "zh-cn": "中国語 (中文)"
     , "zh-tw": "国語 (國語)"

--- a/i18n/pt-br.json
+++ b/i18n/pt-br.json
@@ -9,6 +9,7 @@
 , "language": {
       "_current": "ATUAL"
     , "en": "Inglês (English)"
+    , "fr": "Francês (français)"
     , "ja": "Japonês (日本語)"
     , "zh-cn": "Chinês (中文)"
     , "zh-tw": "Taiuanês (國語)"

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -8,13 +8,14 @@
   }
 , "language": {
       "_current": "ТЕКУЩИЙ"
-    , "en": "English"
-    , "ja": "Japanese (日本語)"
-    , "zh-cn": "Chinese (中文)"
-    , "zh-tw": "Taiwanese (國語)"
-    , "es": "Spanish (Español)"
-    , "pt-br": "Brazilian Portuguese (Português)"
-    , "ru": "Russian (Русский)"
+    , "en": "Английский (English)"
+    , "fr": "Французский (français)"
+    , "ja": "Японский (日本語)"
+    , "zh-cn": "Китайский (中文)"
+    , "zh-tw": "Тайваньская (國語)"
+    , "es": "Испанский (Español)"
+    , "pt-br": "Бразильский португальский (Português)"
+    , "ru": "Русский"
   }
 , "error": {
       "exercise": {

--- a/i18n/usage/fr.txt
+++ b/i18n/usage/fr.txt
@@ -1,0 +1,22 @@
+{bold}{yellow}Utilisation{/yellow}{/bold}
+
+  {bold}{green}{appname}{/green}{/bold}
+    Affiche un menu pour choisir interactivement un exercice.
+  {bold}{green}{appname}{/green} list{/bold}
+    Affiche une liste des exercices, à raison d’un par ligne.
+  {bold}{green}{appname}{/green} select NAME{/bold}
+    Sélectionne un exercice.
+  {bold}{green}{appname}{/green} current{/bold}
+    Affiche l’exercice en cours.
+  {bold}{green}{appname}{/green} print{/bold}
+    Affiche les instructions pour l’exercice en cours.
+  {bold}{green}{appname}{/green} next{/bold}
+    Affiche les instructions pour le prochain exercice que vous n’avez pas encore terminé, après l’exercice courant.
+  {bold}{green}{appname}{/green} reset{/bold}
+    Réinitialise votre progression pour cet atelier.
+  {bold}{green}{appname}{/green} run program.js{/bold}
+    Exécute votre programme dans le contexte décrit par les instructions de l’exercice.
+  {bold}{green}{appname}{/green} verify program.js{/bold}
+    Vérifie que votre programme résoud l’exercice.
+  {bold}{green}{appname}{/green} -l <language>{/bold}
+    Utilise la langue spécifiée pour l’atelier.

--- a/i18n/zh-cn.json
+++ b/i18n/zh-cn.json
@@ -9,6 +9,7 @@
 , "language": {
       "_current": "当前"
     , "en": "英语 (English)"
+    , "fr": "法国 (français)"
     , "ja": "日语 (日本語)"
     , "zh-cn": "简体中文"
     , "zh-tw": "繁体中文"

--- a/i18n/zh-tw.json
+++ b/i18n/zh-tw.json
@@ -9,6 +9,7 @@
 , "language": {
 	  "_current": "CURRENT"
 	, "en": "英语 (English)"
+	, "fr": "法國 (français)"
 	, "ja": "日语 (日本語)"
 	, "zh-cn": "中文"
 	, "zh-tw": "國語"

--- a/languageMenu.js
+++ b/languageMenu.js
@@ -3,7 +3,7 @@ const chalk = require('chalk')
 const menu = require('./menu')
 
 function showMenu (opts, i18n) {
-    
+
   var __ = i18n.__
 
   opts.entries = [

--- a/menu.js
+++ b/menu.js
@@ -28,7 +28,7 @@ function showMenu (opts, i18n) {
   function emit(event, value) {
     return process.nextTick.bind(process, emitter.emit.bind(emitter, event, value))
   }
-  
+
   function addEntry(entry) {
     menu.add(applyTextMarker(entry.name, entry.marker || '', opts.width), emit(entry.event, entry.payload))
   }
@@ -68,7 +68,7 @@ function showMenu (opts, i18n) {
   })
 
   menu.createStream().pipe(process.stdout)
-  
+
   return emitter
 }
 

--- a/util.js
+++ b/util.js
@@ -30,7 +30,7 @@ function assertFs (type, options, field, base, fallback) {
       throw new TypeError('need to provide an "' + field + '" String option')
 
   try {
-    stat = fs.statSync(target) 
+    stat = fs.statSync(target)
   } catch (e) {}
 
   if (!stat || !(type === 'file' ? stat.isFile() : stat.isDirectory()))

--- a/workshopper.js
+++ b/workshopper.js
@@ -133,7 +133,7 @@ function Workshopper (options) {
     } else {
       selected = this.exercises.filter(function (exercise) {
         return selected === this.__('exercise.' + exercise)
-      }.bind(this))[0] || selected; 
+      }.bind(this))[0] || selected;
     }
     onselect.call(this, selected)
     return
@@ -153,32 +153,32 @@ function Workshopper (options) {
 
     return this.execute(exercise, mode, argv._.slice(1))
   }
-  
+
   if (argv._[0] == 'next') {
     var remainingAfterCurrent = this.exercises.slice(this.exercises.indexOf(this.current))
-    
-    var completed = this.getData('completed')    
+
+    var completed = this.getData('completed')
     var incompleteAfterCurrent = remainingAfterCurrent.filter(function (elem) {
       return completed.indexOf(elem) < 0
     })
-    
+
     if (incompleteAfterCurrent.length === 0)
       return console.log(this.__('error.no_uncomplete_left') + '\n')
-    
+
     return onselect.call(this, incompleteAfterCurrent[0])
   }
-  
+
   if (argv._[0] == 'next') {
     var remainingAfterCurrent = this.exercises.slice(this.exercises.indexOf(this.current))
-    
-    var completed = this.getData('completed')    
+
+    var completed = this.getData('completed')
     var incompleteAfterCurrent = remainingAfterCurrent.filter(function (elem) {
       return completed.indexOf(elem) < 0
     })
-    
+
     if (incompleteAfterCurrent.length === 0)
       return console.log('There are no incomplete exercises after the current exercise\n')
-    
+
     return onselect.call(this, incompleteAfterCurrent[0])
   }
 


### PR DESCRIPTION
Hi!

This provides:

* Full `fr` translations across the board
* `fr` language defs in all languages' language menus
* Fixes for Russian language names in Russian language menu
* A few occurrences of whitespace cleanup (trailings, EOF newlines, etc.)
* Availability of all languages in the provided `foo` example, so we can test our core translations more easily with `node examples/foo.js`

This is part of the effort in nodeschool/organizers#64

I'm also at work on upgrading many actual workshops so they use the latest workshopper, workshopper-exercise, etc. in order to translate them in FR.

BTW, releasing a new version with this on npm, say 2.2.1, would be awesome so I can update my deps :smile: 