### PR TITLE
Update terminal-menu, show error on non-tty

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -29,7 +29,8 @@
       "loading": "Fehler beim Laden der Aufgabe: {{{err}}}"
     },
     "no_uncomplete_left": "Es gibt keine unvollständigen Aufgaben nach der aktuellen Aufgabe",
-    "cleanup": "Fehler beim Aufräumen: {{{err}}}"
+    "cleanup": "Fehler beim Aufräumen: {{{err}}}",
+    "notty": "Bitte führe das Programm in einem Terminal (tty) aus." 
   },
   "solution": {
     "fail": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -29,7 +29,8 @@
       "loading": "Error loading exercise text: {{{err}}}"
     },
     "no_uncomplete_left": "There are no incomplete exercises after the current exercise",
-    "cleanup": "Error cleaning up: {{{err}}}"
+    "cleanup": "Error cleaning up: {{{err}}}",
+    "notty": "Please start this in a tty-compatible terminal program."
   },
   "solution": {
     "fail": {

--- a/menu.js
+++ b/menu.js
@@ -67,7 +67,22 @@ function showMenu (opts, i18n) {
     menu.close()
   })
 
-  menu.createStream().pipe(process.stdout)
+  process.stdin
+    .pipe(menu.createStream())
+    .pipe(process.stdout)
+
+  if(!process.stdin.isTTY) {
+    menu.reset()
+    console.error(__('error.notty'))
+    process.exit(1)
+  } else {
+    process.stdin.setRawMode(true)  
+  }
+
+  menu.on('close', function () {
+    process.stdin.setRawMode(false)
+    process.stdin.end()
+  })
 
   return emitter
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mkdirp": "~0.3.5",
     "msee": "~0.1.1",
     "optimist": "~0.6.1",
-    "terminal-menu": "^1.0.2",
+    "terminal-menu": "^2.1.1",
     "visualwidth": "~0.0.1",
     "xtend": "~3.0.0"
   },


### PR DESCRIPTION
Hey,

this updates terminal-menu to the newest version  `2.1.1`. It also introduces an error message for people starting the workshopper from a non-tty (like cygwin).

Best,
Finn