### PR TITLE
Update msee dependency to latest version for ES6 syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "i18n-core": "^1.3.2",
     "map-async": "~0.1.1",
     "mkdirp": "~0.3.5",
-    "msee": "~0.1.1",
+    "msee": "^0.1.2",
     "optimist": "~0.6.1",
     "terminal-menu": "^2.1.1",
     "visualwidth": "~0.0.1",


### PR DESCRIPTION
Syntax highlighting for ES6!

msee has [just been updated](https://github.com/firede/msee/pull/14) with the latest version of `cardinal`.

Related discussion: https://github.com/workshopper/workshopper/issues/95.
