### PR TITLE
Fix menu closing handler

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -73,6 +73,9 @@ function showMenu (opts, i18n) {
     menu.y = 0
     menu.reset()
     menu.close()
+  })
+
+  menu.on('close', function () {
     process.stdin.pause()
     process.stdin.removeListener('data', passDataToMenu)
     menuStream.unpipe(process.stdout)


### PR DESCRIPTION
This commit fixes #108 in that it prevents the "write after end" error. However, the terminal is not completely reset after exit through keyboard due to substack/terminal-menu#30. A fix for that issue is available at substack/terminal-menu#31.
